### PR TITLE
Added descriptive status (badges) on the devices table

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -11,7 +11,6 @@ import {
   getUsers,
   getEditUser,
   postEditUser,
-  getDeleteUser,
 } from "../controllers/users.js";
 import auth from "../config/auth.js";
 

--- a/views/devices/index.ejs
+++ b/views/devices/index.ejs
@@ -33,7 +33,10 @@
               <%= device.code %>
             </td>
             <td>
-              <%= device.status %>
+              <span
+                class="badge rounded-pill bg-<%= device.status == 0 ? 'warning' : device.status == 1 ? 'success' : 'danger' %>">
+                <%= device.status==0 ? 'Not Assigned' : device.status==1 ? 'Assigned' : 'Decommissined' %>
+              </span>
             </td>
             <td>
               <%= device.createdAt.toLocaleString() %>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -86,11 +86,11 @@
 
         <div class="d-flex">
           <% if (user_session) { %>
-            <a href="/users/logout" class="btn btn-danger my-2 my-sm-0 me-2">Logout</a>
+            <a href="/users/logout" class="btn btn-sm btn-danger my-2 my-sm-0 me-2">Logout</a>
             <% } else { %>
 
-              <a href="/users/login" class="btn btn-secondary my-2 my-sm-0 me-2">Login</a>
-              <a href="/users/register" class="btn btn-secondary my-2 my-sm-0">Register</a>
+              <a href="/users/login" class="btn btn-sm btn-secondary my-2 my-sm-0 me-2">Login</a>
+              <a href="/users/register" class="btn btn-sm btn-secondary my-2 my-sm-0">Register</a>
               <% } %>
         </div>
       </div>


### PR DESCRIPTION
Integer statuses do not give a clear description of what the status is to an end user. This fixes that on the devices table.

TO-DO: do the same for the statuses on the other tables.